### PR TITLE
Fix configuration in platformio.ini file

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:TTGO T-Beam]
+[env:TTGO_T-Beam]
 platform = espressif32
 board = ttgo-t-beam
 framework = arduino
@@ -31,8 +31,8 @@ build_flags =
 ; upload_port = /dev/cu.wchusbserial*
 ; monitor_port = /dev/cu.wchusbserial*
 
-[env: TTGO T-Beam (KeyDump)]
-extends = env:TTGO T-Beam
+[env:KeyDump]
+extends = env:TTGO_T-Beam
 build_src_filter = +<keydump.cpp> -<main.cpp>
 lib_deps = 
 	lewisxhe/AXP202X_Library@^1.1.3


### PR DESCRIPTION
Replace whitespaces with underscores to avoid PlatformIO error: "Invalid environment name 'TTGO T-Beam'. The name can contain alphanumeric, underscore, and hyphen characters (a-z, 0-9, -, _)"